### PR TITLE
Feat: make validation optional to allow other VAT calculations

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -104,12 +104,12 @@ module Secretariat
       )
     end
 
-    def to_xml(version: 1)
+    def to_xml(version: 1, validate: true)
       if version < 1 || version > 2
         raise 'Unsupported Document Version'
       end
 
-      unless valid?
+      if validate && !valid?
         raise ValidationError.new("Invoice is invalid", errors)
       end
 
@@ -147,7 +147,7 @@ module Secretariat
 
             if version == 2
               line_items.each_with_index do |item, i|
-                item.to_xml(xml, i + 1, version: version) # one indexed
+                item.to_xml(xml, i + 1, version: version, validate: validate) # one indexed
               end
             end
 

--- a/lib/secretariat/line_item.rb
+++ b/lib/secretariat/line_item.rb
@@ -84,8 +84,8 @@ module Secretariat
       TAX_CATEGORY_CODES[tax_category] || 'S'
     end
 
-    def to_xml(xml, line_item_index, version: 2)
-      if !valid?
+    def to_xml(xml, line_item_index, version: 2, validate: true)
+      if validate && !valid?
         pp errors
         raise ValidationError.new("LineItem #{line_item_index} is invalid", errors)
       end


### PR DESCRIPTION
Here is another change that we implemented:

We calulate the VAT slightly differently, so running to_xml gave errors in some cases:

- no down rounding of the total sum (as done in Invoice#valid?), but VAT of invoice = sum of VAT of line items, no rounding on invoice level needed.
- line_items: validation checks for 3 decimal numbers: ["Tax and calculated tax deviate: -9.02 / -9.025"]

So, I've added an option on to_xml(validate: false) to disable validation in invoice and line items.
