### PR TITLE
Setup Github Actions CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,39 @@
+  # This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.2.2', '3.3', head]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu' # See 'Supported distributions' for available options
+        java-version: '21'
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake test

--- a/secretariat.gemspec
+++ b/secretariat.gemspec
@@ -1,5 +1,5 @@
 require_relative 'lib/secretariat/version'
-require 'rake'
+#require 'rake'
 Gem::Specification.new do |s|
   s.name        = 'secretariat'
   s.version     = Secretariat::VERSION
@@ -8,7 +8,12 @@ Gem::Specification.new do |s|
   s.description = "a tool to help generate and validate ZUGFeRD invoice xml files"
   s.authors     = ["Jan Krutisch"]
   s.email       = 'jan@krutisch.de'
-  s.files       = FileList['lib/**/*.rb', 'bin/*.jar', 'schemas/**/*', 'README.md']
+  
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  s.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
   s.homepage    = 'https://github.com/halfbyte/ruby-secretariat'
   s.license       = 'Apache-2.0'
 


### PR DESCRIPTION
To avoid problems in the future :) 

I made a basic Ruby Workflow. For that to work, I had to modify the gemspec to avoid loading Rake here.

You can see my fork's action runs: https://github.com/pludoni/ruby-secretariat/actions

- Using rake in Gemspec leads to errors, as Rake is not installed by default, so I replaced the FileList with the default stuff `bundle gem` generates
- Chose 3 Ruby versions to test, 3.2.2 could be dropped or changed to newer 3.2 release - that was just the default stuff that the Action Wizard put in there with a pinned setup-ruby action...
