### PR TITLE
support multiple tax rates per invoice

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -66,7 +66,7 @@ module Secretariat
       line_items.each do |line_item|
         taxes[line_item.tax_percent] = Tax.new(tax_percent: BigDecimal(line_item.tax_percent)) if taxes[line_item.tax_percent].nil?
         taxes[line_item.tax_percent].tax_amount += BigDecimal(line_item.tax_amount)
-        taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.net_amount)
+        taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.net_amount) * line_item.quantity
       end
       taxes.values
     end
@@ -86,7 +86,7 @@ module Secretariat
       end
       summed_tax_base_amount = taxes.sum(&:base_amount)
       if basis != summed_tax_base_amount
-        @errors << "Base amount and summed base amounts deviate: #{basis} / #{summed_tax_base_amount}"
+        @errors << "Base amount and summed tax base amount deviate: #{basis} / #{summed_tax_base_amount}"
         return false
       end
       taxes.each do |tax|

--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -61,6 +61,16 @@ module Secretariat
       TAX_CATEGORY_CODES[tax_category] || 'S'
     end
 
+    def taxes
+      taxes = {}
+      line_items.each do |line_item|
+        taxes[line_item.tax_percent] = Tax.new(tax_percent: BigDecimal(line_item.tax_percent)) if taxes[line_item.tax_percent].nil?
+        taxes[line_item.tax_percent].tax_amount += BigDecimal(line_item.tax_amount)
+        taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.net_amount)
+      end
+      taxes.values
+    end
+
     def payment_code
       PAYMENT_CODES[payment_type] || '1'
     end
@@ -69,11 +79,23 @@ module Secretariat
       @errors = []
       tax = BigDecimal(tax_amount)
       basis = BigDecimal(basis_amount)
-      calc_tax = basis * BigDecimal(tax_percent) / BigDecimal(100)
-      calc_tax = calc_tax.round(2, :down)
-      if tax != calc_tax
-        @errors << "Tax amount and calculated tax amount deviate: #{tax} / #{calc_tax}"
+      summed_tax_amount = taxes.sum(&:tax_amount)
+      if tax != summed_tax_amount
+        @errors << "Tax amount and summed tax amounts deviate: #{tax_amount} / #{summed_tax_amount}"
         return false
+      end
+      summed_tax_base_amount = taxes.sum(&:base_amount)
+      if basis != summed_tax_base_amount
+        @errors << "Base amount and summed base amounts deviate: #{basis} / #{summed_tax_base_amount}"
+        return false
+      end
+      taxes.each do |tax|
+        calc_tax = tax.base_amount * BigDecimal(tax.tax_percent) / BigDecimal(100)
+        calc_tax = calc_tax.round(2, :down)
+        if tax.tax_amount != calc_tax
+          @errors << "Tax amount and calculated tax amount deviate for rate #{tax.tax_percent}: #{tax.tax_amount} / #{calc_tax}"
+          return false
+        end
       end
       grand_total = BigDecimal(grand_total_amount)
       calc_grand_total = basis + tax
@@ -200,18 +222,19 @@ module Secretariat
                   end
                 end
               end
-              xml['ram'].ApplicableTradeTax do
+              taxes.each do |tax|
+                xml['ram'].ApplicableTradeTax do
+                  Helpers.currency_element(xml, 'ram', 'CalculatedAmount', tax.tax_amount, currency_code, add_currency: version == 1)
+                  xml['ram'].TypeCode 'VAT'
+                  if tax_reason_text && tax_reason_text != ''
+                    xml['ram'].ExemptionReason tax_reason_text
+                  end
+                  Helpers.currency_element(xml, 'ram', 'BasisAmount', tax.base_amount, currency_code, add_currency: version == 1)
+                  xml['ram'].CategoryCode tax_category_code(version: version)
 
-                Helpers.currency_element(xml, 'ram', 'CalculatedAmount', tax_amount, currency_code, add_currency: version == 1)
-                xml['ram'].TypeCode 'VAT'
-                if tax_reason_text && tax_reason_text != ''
-                  xml['ram'].ExemptionReason tax_reason_text
+                  percent = by_version(version, 'ApplicablePercent', 'RateApplicablePercent')
+                  xml['ram'].send(percent, Helpers.format(tax.tax_percent))
                 end
-                Helpers.currency_element(xml, 'ram', 'BasisAmount', basis_amount, currency_code, add_currency: version == 1)
-                xml['ram'].CategoryCode tax_category_code(version: version)
-
-                percent = by_version(version, 'ApplicablePercent', 'RateApplicablePercent')
-                xml['ram'].send(percent, Helpers.format(tax_percent))
               end
               if version == 2 && service_period_start && service_period_end
                 xml['ram'].BillingSpecifiedPeriod do

--- a/lib/secretariat/tax.rb
+++ b/lib/secretariat/tax.rb
@@ -12,15 +12,23 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 =end
 
-require_relative 'secretariat/version'
-require_relative 'secretariat/constants'
-require_relative 'secretariat/helpers'
-require_relative 'secretariat/versioner'
-require_relative 'secretariat/validation_error'
-require_relative 'secretariat/invoice'
-require_relative 'secretariat/trade_party'
-require_relative 'secretariat/line_item'
-require_relative 'secretariat/validator'
-require_relative 'secretariat/tax'
+require 'bigdecimal'
+
+module Secretariat
+  Tax = Struct.new('Tax',
+    :tax_percent,
+    :tax_amount,
+    :base_amount,
+    keyword_init: true
+  ) do
+
+    def initialize(*)
+      super
+      self.tax_amount = 0
+      self.base_amount = 0
+    end
+  end
+end

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -132,11 +132,9 @@ module Secretariat
         name: 'Depfu Starter Plan',
         quantity: 1,
         unit: :PIECE,
-        gross_amount: '29',
+        gross_amount: '23.80',
         net_amount: '20',
         charge_amount: '20',
-        discount_amount: '9',
-        discount_reason: 'Rabatt',
         tax_category: :STANDARDRATE,
         tax_percent: '19',
         tax_amount: "3.80",
@@ -145,14 +143,14 @@ module Secretariat
       )
       line_item2 = LineItem.new(
         name: 'Cup of Coffee',
-        quantity: 1,
+        quantity: 2,
         unit: :PIECE,
-        gross_amount: '2',
+        gross_amount: '2.14',
         net_amount: '2',
-        charge_amount: '2',
+        charge_amount: '4',
         tax_category: :STANDARDRATE,
         tax_percent: '7',
-        tax_amount: "0.14",
+        tax_amount: "0.28",
         origin_country_code: 'DE',
         currency_code: 'EUR'
       )
@@ -171,11 +169,11 @@ module Secretariat
         payment_iban: 'DE02120300000000202051',
         payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
         tax_category: :STANDARDRATE,
-        tax_amount: '3.94',
-        basis_amount: '22',
-        grand_total_amount: '25.94',
+        tax_amount: '4.08',
+        basis_amount: '24',
+        grand_total_amount: '28.08',
         due_amount: 0,
-        paid_amount: '25.94',
+        paid_amount: '28.08',
         payment_due_date: Date.today + 14
       )
     end

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -46,7 +46,6 @@ module Secretariat
         payment_type: :CREDITCARD,
         payment_text: 'Kreditkarte',
         tax_category: :REVERSECHARGE,
-        tax_percent: 0,
         tax_amount: '0',
         basis_amount: '29',
         grand_total_amount: 29,
@@ -103,12 +102,80 @@ module Secretariat
         payment_iban: 'DE02120300000000202051',
         payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
         tax_category: :STANDARDRATE,
-        tax_percent: '19',
         tax_amount: '3.80',
         basis_amount: '20',
         grand_total_amount: '23.80',
         due_amount: 0,
         paid_amount: '23.80',
+        payment_due_date: Date.today + 14
+      )
+    end
+
+    def make_de_invoice_with_multiple_tax_rates
+      seller = TradeParty.new(
+        name: 'Depfu inc',
+        street1: 'Quickbornstr. 46',
+        city: 'Hamburg',
+        postal_code: '20253',
+        country_id: 'DE',
+        vat_id: 'DE304755032'
+      )
+      buyer = TradeParty.new(
+        name: 'Depfu inc',
+        street1: 'Quickbornstr. 46',
+        city: 'Hamburg',
+        postal_code: '20253',
+        country_id: 'DE',
+        vat_id: 'DE304755032'
+      )
+      line_item = LineItem.new(
+        name: 'Depfu Starter Plan',
+        quantity: 1,
+        unit: :PIECE,
+        gross_amount: '29',
+        net_amount: '20',
+        charge_amount: '20',
+        discount_amount: '9',
+        discount_reason: 'Rabatt',
+        tax_category: :STANDARDRATE,
+        tax_percent: '19',
+        tax_amount: "3.80",
+        origin_country_code: 'DE',
+        currency_code: 'EUR'
+      )
+      line_item2 = LineItem.new(
+        name: 'Cup of Coffee',
+        quantity: 1,
+        unit: :PIECE,
+        gross_amount: '2',
+        net_amount: '2',
+        charge_amount: '2',
+        tax_category: :STANDARDRATE,
+        tax_percent: '7',
+        tax_amount: "0.14",
+        origin_country_code: 'DE',
+        currency_code: 'EUR'
+      )
+      Invoice.new(
+        id: '12345',
+        issue_date: Date.today,
+        service_period_start: Date.today,
+        service_period_end: Date.today + 30,
+        seller: seller,
+        buyer: buyer,
+        buyer_reference: "112233",
+        line_items: [line_item, line_item2],
+        currency_code: 'USD',
+        payment_type: :CREDITCARD,
+        payment_text: 'Kreditkarte',
+        payment_iban: 'DE02120300000000202051',
+        payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
+        tax_category: :STANDARDRATE,
+        tax_amount: '3.94',
+        basis_amount: '22',
+        grand_total_amount: '25.94',
+        due_amount: 0,
+        paid_amount: '25.94',
         payment_due_date: Date.today + 14
       )
     end
@@ -194,6 +261,45 @@ module Secretariat
 
     def test_simple_de_invoice_against_schematron
       xml = make_de_invoice.to_xml(version: 1)
+      v = Validator.new(xml, version: 1)
+      errors = v.validate_against_schematron
+      if !errors.empty?
+        puts xml
+        errors.each do |error|
+          puts "#{error[:line]}: #{error[:message]}"
+        end
+      end
+      assert_equal [], errors
+    end
+
+    def test_de_multiple_taxes_invoice_v1
+      xml = make_de_invoice_with_multiple_tax_rates.to_xml(version: 1)
+      v = Validator.new(xml, version: 1)
+      errors = v.validate_against_schema
+      if !errors.empty?
+        puts xml
+        errors.each do |error|
+          puts error
+        end
+      end
+      assert_equal [], errors
+    end
+
+    def test_de_multiple_taxes_invoice_v2
+      xml = make_de_invoice_with_multiple_tax_rates.to_xml(version: 2)
+      v = Validator.new(xml, version: 2)
+      errors = v.validate_against_schema
+      if !errors.empty?
+        puts xml
+        errors.each do |error|
+          puts error
+        end
+      end
+      assert_equal [], errors
+    end
+
+    def test_de_multiple_taxes_invoice_against_schematron
+      xml = make_de_invoice_with_multiple_tax_rates.to_xml(version: 1)
       v = Validator.new(xml, version: 1)
       errors = v.validate_against_schematron
       if !errors.empty?


### PR DESCRIPTION
fix #6 

Adds support for multiple tax rates per invoice.
No changes required in the API, but Invoice.tax_rate is now obsolete. I left it in because you asked for backwards compatibility, so we don't throw an error if trying to set it. Now, numerical tax information is taken from the line_items, Invoice.tax_amount is still used for validation and for TaxTotalAmount

tax_category and tax_reason are still taken from the invoice:
- German 7% and 19% are both the standard category and I don't currently see a case where one (but not another in the same invoice) line item would have a different _category_
- tax_reason is simply not used by us. It could also go into the line_item object, but then we'd have to send it for each line_item - meh

Also, feel free to suggest better syntax, I'm much more of a Rails than pure Ruby person so if you don't like something by all means let's change it :)