### PR TITLE
Take tax_category from Line Items and Fix validation: rounding for subcent amounts

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -91,7 +91,7 @@ module Secretariat
       end
       taxes.each do |tax|
         calc_tax = tax.base_amount * BigDecimal(tax.tax_percent) / BigDecimal(100)
-        calc_tax = calc_tax.round(2, :down)
+        calc_tax = calc_tax.round(2)
         if tax.tax_amount != calc_tax
           @errors << "Tax amount and calculated tax amount deviate for rate #{tax.tax_percent}: #{tax.tax_amount} / #{calc_tax}"
           return false

--- a/lib/secretariat/line_item.rb
+++ b/lib/secretariat/line_item.rb
@@ -65,6 +65,7 @@ module Secretariat
       end
 
       calculated_tax = charge_price * BigDecimal(tax_percent) / BigDecimal(100)
+      calculated_tax = calculated_tax.round(2)
       if calculated_tax != tax
         @errors << "Tax and calculated tax deviate: #{tax} / #{calculated_tax}"
         return false

--- a/lib/secretariat/tax.rb
+++ b/lib/secretariat/tax.rb
@@ -20,6 +20,7 @@ module Secretariat
   Tax = Struct.new('Tax',
     :tax_percent,
     :tax_amount,
+    :tax_category,
     :base_amount,
     keyword_init: true
   ) do

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -143,14 +143,14 @@ module Secretariat
       )
       line_item2 = LineItem.new(
         name: 'Cup of Coffee',
-        quantity: 2,
+        quantity: 1,
         unit: :PIECE,
-        gross_amount: '2.14',
-        net_amount: '2',
-        charge_amount: '4',
+        gross_amount: '2.68',
+        net_amount: '2.50',
+        charge_amount: '2.50',
         tax_category: :STANDARDRATE,
         tax_percent: '7',
-        tax_amount: "0.28",
+        tax_amount: "0.18",
         origin_country_code: 'DE',
         currency_code: 'EUR'
       )
@@ -169,11 +169,11 @@ module Secretariat
         payment_iban: 'DE02120300000000202051',
         payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
         tax_category: :STANDARDRATE,
-        tax_amount: '4.08',
-        basis_amount: '24',
-        grand_total_amount: '28.08',
+        tax_amount: '3.98',
+        basis_amount: '22.50',
+        grand_total_amount: '26.48',
         due_amount: 0,
-        paid_amount: '28.08',
+        paid_amount: '26.48',
         payment_due_date: Date.today + 14
       )
     end

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -154,6 +154,19 @@ module Secretariat
         origin_country_code: 'DE',
         currency_code: 'EUR'
       )
+      line_item3 = LineItem.new(
+        name: 'Returnable Deposit',
+        quantity: 1,
+        unit: :PIECE,
+        gross_amount: '5',
+        net_amount: '5',
+        charge_amount: '5',
+        tax_category: :ZEROTAXPRODUCTS,
+        tax_percent: '0',
+        tax_amount: "0",
+        origin_country_code: 'DE',
+        currency_code: 'EUR'
+      )
       Invoice.new(
         id: '12345',
         issue_date: Date.today,
@@ -162,7 +175,7 @@ module Secretariat
         seller: seller,
         buyer: buyer,
         buyer_reference: "112233",
-        line_items: [line_item, line_item2],
+        line_items: [line_item, line_item2, line_item3],
         currency_code: 'USD',
         payment_type: :CREDITCARD,
         payment_text: 'Kreditkarte',
@@ -170,10 +183,10 @@ module Secretariat
         payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
         tax_category: :STANDARDRATE,
         tax_amount: '7.78',
-        basis_amount: '42.50',
-        grand_total_amount: '50.28',
+        basis_amount: '47.50',
+        grand_total_amount: '55.28',
         due_amount: 0,
-        paid_amount: '50.28',
+        paid_amount: '55.28',
         payment_due_date: Date.today + 14
       )
     end
@@ -296,9 +309,21 @@ module Secretariat
       assert_equal [], errors
     end
 
-    def test_de_multiple_taxes_invoice_against_schematron
+    def test_de_multiple_taxes_invoice_against_schematron_1
       xml = make_de_invoice_with_multiple_tax_rates.to_xml(version: 1)
       v = Validator.new(xml, version: 1)
+      errors = v.validate_against_schematron
+      if !errors.empty?
+        puts xml
+        errors.each do |error|
+          puts "#{error[:line]}: #{error[:message]}"
+        end
+      end
+      assert_equal [], errors
+    end
+    def test_de_multiple_taxes_invoice_against_schematron_2
+      xml = make_de_invoice_with_multiple_tax_rates.to_xml(version: 2)
+      v = Validator.new(xml, version: 2)
       errors = v.validate_against_schematron
       if !errors.empty?
         puts xml

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -130,14 +130,14 @@ module Secretariat
       )
       line_item = LineItem.new(
         name: 'Depfu Starter Plan',
-        quantity: 1,
+        quantity: 2,
         unit: :PIECE,
         gross_amount: '23.80',
         net_amount: '20',
-        charge_amount: '20',
+        charge_amount: '40',
         tax_category: :STANDARDRATE,
         tax_percent: '19',
-        tax_amount: "3.80",
+        tax_amount: "7.60",
         origin_country_code: 'DE',
         currency_code: 'EUR'
       )
@@ -169,11 +169,11 @@ module Secretariat
         payment_iban: 'DE02120300000000202051',
         payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
         tax_category: :STANDARDRATE,
-        tax_amount: '3.98',
-        basis_amount: '22.50',
-        grand_total_amount: '26.48',
+        tax_amount: '7.78',
+        basis_amount: '42.50',
+        grand_total_amount: '50.28',
         due_amount: 0,
-        paid_amount: '26.48',
+        paid_amount: '50.28',
         payment_due_date: Date.today + 14
       )
     end


### PR DESCRIPTION
Now taking the tax_category, which is set per tax rate, from the line_items.
This is needed because different taxes can be on one invoice, and they aren't all guaranteed to be of the same category
(see #16)

See also my comment from there:

> This would also render Invoice.tax_category nearly obsolete, which is then only really used in tax_reason_text, which is only used at the per-tax level, so that also could be changed to not use invoice.tax_category

I kept that part in place because I wanted to change as little as possible, but in theory I could also do that.

Also changing the rounding in the validation in two places:

- on the invoice, use .round(2) instead of .round(2, :down). As far as I understand, in Germany there is no forced rounding down
- on the invoice item, introduce .round(2) as well

the resulting invoice passes schematron and various online zugferd checkers.

fix #13 
fix #16 