### PR TITLE
Add payment reference

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -28,6 +28,7 @@ module Secretariat
     :line_items,
     :currency_code,
     :payment_type,
+    :payment_reference,
     :payment_text,
     :payment_terms_text,
     :payment_due_date,
@@ -212,6 +213,9 @@ module Secretariat
             end
             trade_settlement = by_version(version, 'ApplicableSupplyChainTradeSettlement', 'ApplicableHeaderTradeSettlement')
             xml['ram'].send(trade_settlement) do
+              if payment_reference && payment_reference != ''
+                xml['ram'].PaymentReference payment_reference
+              end
               xml['ram'].InvoiceCurrencyCode currency_code
               xml['ram'].SpecifiedTradeSettlementPaymentMeans do
                 xml['ram'].TypeCode payment_code

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -99,6 +99,7 @@ module Secretariat
         currency_code: 'USD',
         payment_type: :CREDITCARD,
         payment_text: 'Kreditkarte',
+        payment_reference: 'INV 123123123',
         payment_iban: 'DE02120300000000202051',
         payment_terms_text: "Zahlbar innerhalb von 14 Tagen ohne Abzug",
         tax_category: :STANDARDRATE,


### PR DESCRIPTION
I updated the tools and CI to use latest ruby version and added the field `payment_reference`.