### PR TITLE
add tax_calculation_method :ITEM_BASED which changes tax amount validation to item based

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -113,7 +113,12 @@ module Secretariat
         @errors << "Base amount and summed tax base amount deviate: #{basis} / #{summed_tax_base_amount}"
         return false
       end
-      if tax_calculation_method != :NONE
+      if tax_calculation_method == :ITEM_BASED
+        line_items_tax_amount = line_items.sum(&:tax_amount)
+        if tax_amount != line_items_tax_amount
+          @errors << "Tax amount #{tax_amount} and summed up item tax amounts #{line_items_tax_amount} deviate"
+        end
+      elsif tax_calculation_method != :NONE
         taxes.each do |tax|
           calc_tax = tax.base_amount * BigDecimal(tax.tax_percent) / BigDecimal(100)
           calc_tax = calc_tax.round(2)


### PR DESCRIPTION
Another of those specific use-cases I'm afraid:

We are rounding taxes on a per-line-item basis, not like Secretariat currently validates for on a per-taxrate basis.
The new :NONE option doesn't work here, because it actually changes the taxes. What we need is to just change / skip the"Base amount and summed tax base amount" validation.

By using the new :ITEM_BASED option, the validation now compares the invoice's tax_amount with the sum of the item tax amounts.