### PR TITLE
Use UTF-8 encoding when generating XML

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -167,7 +167,7 @@ module Secretariat
         raise ValidationError.new("Invoice is invalid", errors)
       end
 
-      builder = Nokogiri::XML::Builder.new do |xml|
+      builder = Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
 
         root = by_version(version, 'CrossIndustryDocument', 'CrossIndustryInvoice')
 


### PR DESCRIPTION
Hey, first off, thanks so much for your work on this library, it's really cool!

While playing around with it, I noticed that the formatting of some German characters (ß, ö, ä, ü) was screwed up. I then compared the xml output of this library with the `factur-x.xml` output of a third-party tool (easybill). I noticed that the first line of the xml differs:

`ruby-secretariat`:

```xml
<?xml version="1.0"?>
<!-- ... -->
```

Third-party tool (easybill):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!-- ... -->
```

So the conclusion here is that the encoding is set to UTF-8 explicitly and that that fixes the weird formatting of the characters.

Next, I checked how to add this to `ruby-secretariat`, and the change is simply to pass the UTF-8 encoding to Nokogiri when instantiating it - check out the diff to see what I mean.

This fixes the problem. The XML output now contains the `encoding="UTF-8"`, and the characters are formatted correctly.