### PR TITLE
Add payment_bic and payment_payee_account_name to invoice

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -33,6 +33,8 @@ module Secretariat
     :payment_terms_text,
     :payment_due_date,
     :payment_iban,
+    :payment_bic,
+    :payment_payee_account_name,
     :tax_category,
     :tax_percent,
     :tax_amount,
@@ -263,9 +265,15 @@ module Secretariat
               xml['ram'].SpecifiedTradeSettlementPaymentMeans do
                 xml['ram'].TypeCode payment_code
                 xml['ram'].Information payment_text
-                if payment_iban
+                if payment_iban || payment_payee_account_name
                   xml['ram'].PayeePartyCreditorFinancialAccount do
-                    xml['ram'].IBANID payment_iban
+                    xml['ram'].IBANID payment_iban if payment_iban
+                    xml['ram'].AccountName payment_payee_account_name if payment_payee_account_name
+                  end
+                end
+                if payment_bic
+                  xml['ram'].PayeeSpecifiedCreditorFinancialInstitution do
+                    xml['ram'].BICID payment_bic
                   end
                 end
               end

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -345,6 +345,8 @@ module Secretariat
         payment_reference: 'INV 123123123',
         payment_iban: 'DE02120300000000202051',
         payment_terms_text: "Wir zahlen die Gutschrift unmittelbar aus",
+        payment_bic: 'BYLADEM1001',
+        payment_payee_account_name: 'Depfu inc',
         tax_category: :STANDARDRATE,
         tax_amount: BigDecimal('-38'),
         basis_amount: BigDecimal('-200'),


### PR DESCRIPTION
[Verification of Payee](https://www.europeanpaymentscouncil.eu/what-we-do/other-schemes/verification-payee) will require payee account names to be correct on bank transfers, so having that information within the XML available will be helpful when processing invoices.

The BIC has been added for the sake of completeness.

Happy to change things when required :-)