### PR TITLE
Enable different tax_reason_text per tax

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -57,8 +57,8 @@ module Secretariat
       @errors
     end
 
-    def tax_reason_text
-      tax_reason || TAX_EXEMPTION_REASONS[tax_category]
+    def tax_reason_text(tax)
+      tax_reason || TAX_EXEMPTION_REASONS[tax.tax_category || tax_category]
     end
 
     def tax_category_code(tax, version: 2)
@@ -283,8 +283,8 @@ module Secretariat
                 xml['ram'].ApplicableTradeTax do
                   Helpers.currency_element(xml, 'ram', 'CalculatedAmount', tax.tax_amount, currency_code, add_currency: version == 1)
                   xml['ram'].TypeCode 'VAT'
-                  if tax_reason_text.present?
-                    xml['ram'].ExemptionReason tax_reason_text
+                  if tax_reason_text(tax).present?
+                    xml['ram'].ExemptionReason tax_reason_text(tax)
                   end
                   Helpers.currency_element(xml, 'ram', 'BasisAmount', tax.base_amount, currency_code, add_currency: version == 1)
                   xml['ram'].CategoryCode tax_category_code(tax, version: version)


### PR DESCRIPTION
Check description [here](https://github.com/konvenit/ruby-secretariat/pull/4)