### PR TITLE
Use charge_amount for tax base calculation instead of multiplying net amount with quantity

### DIFF
--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -86,7 +86,7 @@ module Secretariat
         else
           taxes[line_item.tax_percent] = Tax.new(tax_percent: BigDecimal(line_item.tax_percent), tax_category: line_item.tax_category) if taxes[line_item.tax_percent].nil?
           taxes[line_item.tax_percent].tax_amount += BigDecimal(line_item.tax_amount)
-          taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.net_amount) * line_item.quantity
+          taxes[line_item.tax_percent].base_amount += BigDecimal(line_item.charge_amount)
         end
       end
 

--- a/lib/secretariat/trade_party.rb
+++ b/lib/secretariat/trade_party.rb
@@ -20,7 +20,7 @@ module Secretariat
   TradeParty = Struct.new('TradeParty',
     :id,
     :name, :street1, :street2, :city, :postal_code, :country_id, :vat_id, :global_id, :global_id_scheme_id, :tax_id,
-    :person_name, :legal_organization,
+    :person_name, :phone, :email, :legal_organization,
     keyword_init: true,
   ) do
     def to_xml(xml, exclude_tax: false, version: 2)
@@ -40,9 +40,11 @@ module Secretariat
           end
         end
       end
-      if person_name
+      if person_name || phone || email
         xml['ram'].DefinedTradeContact do
-          xml['ram'].PersonName person_name
+          xml['ram'].PersonName(person_name) if person_name
+          xml['ram'].TelephoneUniversalCommunication { (xml['ram'].CompleteNumber(phone)) } if phone
+          xml['ram'].EmailURIUniversalCommunication { xml['ram'].URIID(email) } if email
         end
       end
       xml['ram'].PostalTradeAddress do


### PR DESCRIPTION
I propose to change the tax base amount calculation to adding up the charged amounts rather than multiplying the net amounts with the quantities.

I think this should be fine as charge amount resembles the total net amount before taxes which is what we want to accumulate here:

> BT-131: Positionsnettowert vor Steuern, obligatorisch, unter dem doppelten Tag "ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount"

For why I come up with this: I have a scenario where I only have the charged amount and the quantity available when I have to create a ZUGFeRD invoice. That is a given situation I have no control over. In that case I must derive the net amount by dividing the charged amount by the quantity.
Consider a line item a charged amount of 21,17 € and a quantity of 3. The net amount of such an item is `7.0566666666666666666666666666667`.
If I pass that in to ruby-secretariat, I'll run into a validation error [here](https://github.com/halfbyte/ruby-secretariat/blob/main/lib/secretariat/invoice.rb#L130)  because `(7.0566666666666666666666666666667).to_d * 3.to_d` yields `21.170000000000001` and not `21.17`

This could also be fixed by rounding in one place (adding up the base amount) or the other (validation) but I don't know whether this introduces other subtle arithmetic changes. And the suggested way doesn't need additional rounding in the lib.