### PR TITLE
Omit discout reason if blank

### DIFF
--- a/lib/secretariat/line_item.rb
+++ b/lib/secretariat/line_item.rb
@@ -173,7 +173,7 @@ module Secretariat
                   xml['udt'].Indicator 'false'
                 end
                 Helpers.currency_element(xml, 'ram', 'ActualAmount', discount_amount, currency_code, add_currency: version == 1)
-                xml['ram'].Reason discount_reason
+                xml['ram'].Reason discount_reason if discount_reason
               end
             end
             if version == 1 && discount_amount
@@ -182,7 +182,7 @@ module Secretariat
                   xml['udt'].Indicator 'false'
                 end
                 Helpers.currency_element(xml, 'ram', 'ActualAmount', discount_amount, currency_code, add_currency: version == 1)
-                xml['ram'].Reason discount_reason
+                xml['ram'].Reason discount_reason if discount_reason
               end
             end
           end

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -492,6 +492,7 @@ module Secretariat
       assert_match(/<ram:ExemptionReason>Reverse Charge<\/ram:ExemptionReason>/, xml)
       assert_match(/<ram:RateApplicablePercent>/, xml)
       assert_match(%r{<ram:BuyerTradeParty>\s*<ram:ID>Kunde 4711</ram:ID>}, xml)
+      refute_match(/<ram:Reason>/, xml)
 
       v = Validator.new(xml, version: 2)
       errors = v.validate_against_schema
@@ -790,6 +791,7 @@ module Secretariat
 
       assert_match(/<ram:PaymentReference>#{invoice.payment_reference}<\/ram:PaymentReference>/, xml)
       assert_match(%r{<ram:DefinedTradeContact>\s*<ram:PersonName>Max Mustermann</ram:PersonName>\s*</ram:DefinedTradeContact>}, xml)
+      assert_match(/<ram:Reason>/, xml)
     end
 
     def test_invoice_with_quantity_causing_sub_cent_amounts


### PR DESCRIPTION
Some validators throw a warning if discount_reason is blank.
We shouldn't add it if it's blank.